### PR TITLE
MaterialAlertDialogBuilder to apply material components theme to dialog.

### DIFF
--- a/lib/src/main/java/com/michaelflisar/changelog/internal/ChangelogDialogFragment.java
+++ b/lib/src/main/java/com/michaelflisar/changelog/internal/ChangelogDialogFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.ProgressBar;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.michaelflisar.changelog.ChangelogBuilder;
 import com.michaelflisar.changelog.ChangelogUtil;
 import com.michaelflisar.changelog.R;
@@ -57,7 +58,7 @@ public class ChangelogDialogFragment extends DialogFragment {
             rateButtonText = getContext().getString(R.string.changelog_dialog_rate);
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(title)
                 .setPositiveButton(okButtonText, (dialog, which) -> dialog.dismiss());
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,17 +1,17 @@
 ext {
 
     setup = [
-            compileSdk       : 28,
+            compileSdk       : 29,
             enableDataBinding: true,
             minSdk           : 16,
-            targetSdk        : 28
+            targetSdk        : 29
     ]
 
     androidx = [
-            appcompat   : "1.0.2",
-            recyclerview: "1.0.0",
+            appcompat   : "1.1.0",
+            recyclerview: "1.1.0",
             cardview    : "1.0.0",
-            material    : "1.0.0"
+            material    : "1.2.0-alpha04"
     ]
 
     versions = [


### PR DESCRIPTION
MaterialAlertDialogBuilder to apply material components theme to dialog.

Upgrade compileSdk, targetSdk, AndroidX libraries to make use of MaterialAlertDialogBuilder.