### PR TITLE
Add android:exported attribute

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application>
 
         <activity
-            android:name=".internal.ChangelogActivity"/>
+            android:name=".internal.ChangelogActivity"
+            android:exported="false"/>
 
     </application>
 


### PR DESCRIPTION
I believe I am getting Manifest Merger errors because of the missing attribute in this lib.

Please see [Android Dev documentation](https://developer.android.com/about/versions/12/behavior-changes-12#security):

> If your app targets Android 12 and contains activities, services, or broadcast receivers that use intent filters, you must explicitly declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute for these app components.

I set the attribute to "false" in this PR but setting it to "true" would also fix compatibility with Android 12.